### PR TITLE
Fix apu 20240120

### DIFF
--- a/nes/apu.go
+++ b/nes/apu.go
@@ -2,7 +2,7 @@ package nes
 
 // ref: https://www.nesdev.org/wiki/APU_Frame_Counter
 // > The sequencer is clocked on every other CPU cycle, so 2 CPU cycles = 1 APU cycle.
-// > (with an additional delay of one CPU cycle for the quarter and half frame signals).
+// > ... (with an additional delay of one CPU cycle for the quarter and half frame signals).
 // e.g. APU Cycle 3728.5 => Envelopes & triangle's linear counter
 //
 // ref: https://www.nesdev.org/wiki/APU#Glossary
@@ -119,7 +119,7 @@ func writePulseSweep(p *pulse, val byte) {
 	p.sweepEnabled = (val & 0x80) == 0x80
 	// > The divider's period is P + 1 half-frames
 	p.sweepDivider.period = (uint16((val >> 4) & 0b111)) + 1
-	p.sweepNegate = (val & 0x04) == 0x04
+	p.sweepNegate = (val & 0x08) == 0x08
 	p.sweepShiftCount = val & 0b111
 	// > Side effects	Sets the reload flag
 	p.sweepReload = true
@@ -338,7 +338,7 @@ func (apu *APU) writeFrameCounter(val byte) {
 	//                  0.0, 0.5, 1.0, 1.5, 2.0, 2.0, 2.5, 3.0, ...
 	//         trigger:   t,    ,   t,    ,   t,    ,   t,    , ...
 	//        even/odd:   e,   o,   e,   o,   e,   o,   e,   o, ...
-	// Determine even/odd cycles with APU's master clock(=apu.clock) and delay by a single CPU (at least apu.clock >= 2).
+	// Determine even/odd cycles with APU's master clock(=apu.clock) and delay by a single CPU.
 	// And, the frame counter(sequencer) is clocked on every other CPU cycle(2 CPU cycles = 1 APU cycle, ^ trigger row in the above table).
 	// I decided to adjust it according to the above timing of the trigger.
 

--- a/nes/bus.go
+++ b/nes/bus.go
@@ -29,9 +29,9 @@ func NewBus(ppu *PPU, apu *APU, mapper Mapper, joypad *Joypad) *Bus {
 
 func (bus *Bus) Read(addr uint16) byte {
 	bus.tick(1)
-	return bus.read(addr)
+	return bus._read(addr)
 }
-func (bus *Bus) read(addr uint16) byte {
+func (bus *Bus) _read(addr uint16) byte {
 	switch {
 	case 0x0000 <= addr && addr <= 0x1FFF:
 		// 2KB internal RAM
@@ -60,7 +60,7 @@ func (bus *Bus) read(addr uint16) byte {
 		}
 	case 0x2008 <= addr && addr <= 0x3FFF:
 		// Mirrors of $2000-2007 (repeats every 8 bytes)
-		return bus.read(0x2000 + addr%0x08)
+		return bus._read(0x2000 + addr%0x08)
 	case 0x4000 <= addr && addr <= 0x4017:
 		// NES APU and I/O registers
 		switch {
@@ -88,9 +88,9 @@ func (bus *Bus) read(addr uint16) byte {
 
 func (bus *Bus) Write(addr uint16, val byte) {
 	bus.tick(1)
-	bus.write(addr, val)
+	bus._write(addr, val)
 }
-func (bus *Bus) write(addr uint16, val byte) {
+func (bus *Bus) _write(addr uint16, val byte) {
 	switch {
 	case 0x0000 <= addr && addr <= 0x1FFF:
 		// 2KB internal RAM
@@ -119,7 +119,7 @@ func (bus *Bus) write(addr uint16, val byte) {
 		}
 	case 0x2008 <= addr && addr <= 0x3FFF:
 		// Mirrors of $2000-2007 (repeats every 8 bytes)
-		bus.write(0x2000+addr%0x08, val)
+		bus._write(0x2000+addr%0x08, val)
 	case 0x4000 <= addr && addr <= 0x4017:
 		// NES APU and I/O registers
 		switch {
@@ -166,7 +166,7 @@ func (bus *Bus) write(addr uint16, val byte) {
 		case addr == 0x4014:
 			a := uint16(val) << 8
 			for i := uint16(0); i < 256; i++ {
-				bus.ppu.writeOAMDMAByte(bus.read(a + i))
+				bus.ppu.writeOAMDMAByte(bus._read(a + i))
 			}
 			bus.tickStall(513 + bus.realClock()%2)
 		case addr == 0x4015:

--- a/nes/triangle.go
+++ b/nes/triangle.go
@@ -22,11 +22,10 @@ func newTriangle() *triangle {
 }
 
 func (t *triangle) output() byte {
-	if t.lc.value == 0 {
-		return 0
-	}
-	if t.linearCounter == 0 {
-		return 0
+	// > Write a period value of 0 or 1 to $400A/$400B, causing a very high frequency.
+	// > Due to the averaging effect of the lowpass filter, the resulting value is halfway between 7 and 8.
+	if t.timer.period < 2 {
+		return 7
 	}
 	return triangleTable[t.seqPos]
 }


### PR DESCRIPTION
- Add a dummy read to the NOP instruction
- Bugfix sweep negate flag
  - This resolves an issue where the sound effects of the Super Mario Bros. fireball were strange
- Bugfix triangle silence logic
  - This resolves the issue where the BGM on the second stage of Super Mario Bros. was causing a small noise