### PR TITLE
[20240207] Improve interrupt timing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ It's great because it's written so simple.
 | cpu_exec_space | test_cpu_exec_space_apu.nes | ❌ |
 | cpu_exec_space | test_cpu_exec_space_ppuio.nes | ✅ |
 | cpu_interrupts_v2 | 1-cli_latency.nes | ✅ |
-| cpu_interrupts_v2 | 2-nmi_and_brk.nes | ❌ |
-| cpu_interrupts_v2 | 3-nmi_and_irq.nes | ❌ |
+| cpu_interrupts_v2 | 2-nmi_and_brk.nes | ✅ |
+| cpu_interrupts_v2 | 3-nmi_and_irq.nes | ✅ |
 | cpu_interrupts_v2 | 4-irq_and_dma.nes | ❌ |
 | cpu_interrupts_v2 | 5-branch_delays_irq.nes | ❌ |
 | cpu_reset | ram_after_reset.nes | ❌ |

--- a/nes/apu.go
+++ b/nes/apu.go
@@ -474,6 +474,7 @@ func (apu *APU) tickFrameCounter() {
 		case frameTable[apu.frameMode][3]:
 			if !apu.frameInterruptInhibit {
 				apu.frameInterruptFlag = true
+				apu.cpu.setIRQLine(interruptLineLow)
 			}
 		case frameTable[apu.frameMode][4]:
 			apu.tickQuarterFrameCounter()
@@ -485,6 +486,7 @@ func (apu *APU) tickFrameCounter() {
 		case frameTable[apu.frameMode][5]:
 			if !apu.frameInterruptInhibit {
 				apu.frameInterruptFlag = true
+				apu.cpu.setIRQLine(interruptLineLow)
 			}
 			apu.frameStep = 0
 		}

--- a/tests/cpu_test.go
+++ b/tests/cpu_test.go
@@ -122,6 +122,26 @@ func Test_CPU_OUT_6000(t *testing.T) {
 		// 	"cpu_exec_space/test_cpu_exec_space_apu.nes",
 		// 	"../nes-test-roms/cpu_exec_space/test_cpu_exec_space_apu.nes",
 		// },
+		{
+			"cpu_interrupts_v2/1-cli_latency.nes",
+			"../nes-test-roms/cpu_interrupts_v2/rom_singles/1-cli_latency.nes",
+		},
+		{
+			"cpu_interrupts_v2/2-nmi_and_brk.nes",
+			"../nes-test-roms/cpu_interrupts_v2/rom_singles/2-nmi_and_brk.nes",
+		},
+		{
+			"cpu_interrupts_v2/3-nmi_and_irq.nes",
+			"../nes-test-roms/cpu_interrupts_v2/rom_singles/3-nmi_and_irq.nes",
+		},
+		// {
+		// 	"cpu_interrupts_v2/4-irq_and_dma.nes",
+		// 	"../nes-test-roms/cpu_interrupts_v2/rom_singles/4-irq_and_dma.nes",
+		// },
+		// {
+		// 	"cpu_interrupts_v2/5-branch_delays_irq.nes",
+		// 	"../nes-test-roms/cpu_interrupts_v2/rom_singles/5-branch_delays_irq.nes",
+		// },
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- CPU側で割り込み時間を遅らせる処理を入れる前にAPUテストを通すためにIRQのタイミングを適当にしたのがよくなかった 😇 
  - (ほんとか？)